### PR TITLE
Use basename in .desktop file Exec

### DIFF
--- a/debian/dayon_assistant.desktop
+++ b/debian/dayon_assistant.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Dayon! Assistant
 Version=1.0
-Exec=/usr/bin/dayon_assistant
+Exec=dayon_assistant
 Comment=Offer remote assistance
 Comment[de]=Remotesupport anbieten
 Comment[es]=Ofrecer asistencia remota

--- a/debian/dayon_assisted.desktop
+++ b/debian/dayon_assisted.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Dayon! Assisted
 Version=1.0
-Exec=/usr/bin/dayon_assisted
+Exec=dayon_assisted
 Comment=Request remote assistance
 Comment[de]=Remotesupport erbitten
 Comment[es]=Solicitar asistencia remota


### PR DESCRIPTION
The install prefix could be different from /usr/bin. The installed binary is supposed to be in $PATH, so a basename is best for compatibility.

For example in NixOS the install prefix is /nix/store/<package hash>.