### PR TITLE
fix while focus lost but toggle select state not change bug

### DIFF
--- a/src/main/java/mpo/dayon/assistant/gui/AssistantFrame.java
+++ b/src/main/java/mpo/dayon/assistant/gui/AssistantFrame.java
@@ -237,6 +237,14 @@ class AssistantFrame extends BaseFrame {
             public void focusLost(FocusEvent ev) {
                 if (controlActivated.get()) {
                     fireOnKeyReleased(-1, Character.MIN_VALUE);
+                    if (windowsKeyActivated.get()) {
+                        windowsKeyToggleButton.setSelected(false);
+                        windowsKeyActivated.set(!windowsKeyActivated.get());
+                    }
+                    if (ctrlKeyActivated.get()) {
+                        ctrlKeyToggleButton.setSelected(false);
+                        ctrlKeyActivated.set(!ctrlKeyActivated.get());
+                    }
                 }
             }
         });


### PR DESCRIPTION
When the button is triggered to send the Win key or Ctrl key, it becomes selected. At this point, if the mouse moves outside the Dayon window or if the Dayon window loses focus due to commands like Win+D or Win+E, the FocusListener is triggered, causing all pressed keys, including the Win and Ctrl keys, to be released. However, the buttons for sending the Win and Ctrl keys remain in the selected state. The correct behavior should be to switch the button states to unselected when all pressed keys are released.
![1736384679937](https://github.com/user-attachments/assets/d96163ca-06ba-4e44-ada9-255cc8848e79)
