### PR TITLE
Fix method may throw ArrayIndexOutOfBoundsException bug

### DIFF
--- a/src/main/java/mpo/dayon/assisted/utils/ScreenUtilities.java
+++ b/src/main/java/mpo/dayon/assisted/utils/ScreenUtilities.java
@@ -95,7 +95,7 @@ public final class ScreenUtilities {
 
     private static byte[] doRgbToGray8(Gray8Bits quantization, int[] rgb) {
         final byte[] xLevels = grays[quantization.ordinal()];
-        final int length = rgb.length;
+        final int length = min(rgb.length, gray.length);
         for (int idx = 0; idx < length; idx++) {
             final int pixel = rgb[idx];
             final int red = (pixel >> 16) & 0xFF;


### PR DESCRIPTION
When the ToggleMultiScreenAction action is triggered, it causes the length of the gray[] array to change in ScreenUtilities.java. When the length of gray[] becomes smaller, the doRgbToGray8 method is in the process of performing grayscale conversion. At this point, the length of rgb[] becomes larger than that of gray[], which results in an ArrayIndexOutOfBoundsException and causes the program to crash. I have encountered this issue multiple times.